### PR TITLE
add optional timeout to resource acquisition

### DIFF
--- a/Data/Pool.hs
+++ b/Data/Pool.hs
@@ -312,7 +312,7 @@ takeResource pool@Pool{..} = do
   timeoutSync <- newTVarIO False
   mgr <- Event.getSystemTimerManager
   timeoutKey <-
-    Event.registerTimeout mgr (toSeconds timeout)
+    Event.registerTimeout mgr (toMicroseconds timeout)
       . atomically
       . writeTVar timeoutSync
       $ True
@@ -334,8 +334,8 @@ takeResource pool@Pool{..} = do
   Event.unregisterTimeout mgr timeoutKey
   return (resource, local)
   where
-    toSeconds :: Maybe NominalDiffTime -> Int
-    toSeconds = maybe maxBound ((* 1_000_000) . round . nominalDiffTimeToSeconds)
+    toMicroseconds :: Maybe NominalDiffTime -> Int
+    toMicroseconds = maybe maxBound ((* 1_000_000) . round . nominalDiffTimeToSeconds)
 {-# INLINABLE takeResource #-}
 
 -- | Similar to 'withResource', but only performs the action if a resource could

--- a/Data/Pool.hs
+++ b/Data/Pool.hs
@@ -1,12 +1,11 @@
-{-# LANGUAGE CPP, NamedFieldPuns, RecordWildCards, ScopedTypeVariables, RankNTypes, DeriveDataTypeable #-}
-
-#if MIN_VERSION_monad_control(0,3,0)
-{-# LANGUAGE FlexibleContexts #-}
-#endif
-
-#if !MIN_VERSION_base(4,3,0)
-{-# LANGUAGE RankNTypes #-}
-#endif
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
 -- Module:      Data.Pool
@@ -42,65 +41,51 @@ module Data.Pool
     , destroyAllResources
     ) where
 
-import Control.Concurrent (ThreadId, forkIOWithUnmask, killThread, myThreadId, threadDelay)
-import Control.Concurrent.STM
-import Control.Exception (SomeException, onException, mask_)
-import Control.Monad (forM_, forever, join, liftM3, unless, when)
-import Data.Foldable (foldMap')
-import Data.Hashable (hash)
-import Data.Monoid (Sum(..))
-import Data.IORef (IORef, newIORef, mkWeakIORef)
-import Data.List (partition)
-import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime)
-import Data.Typeable (Typeable)
-import GHC.Conc.Sync (labelThread)
-import qualified Control.Exception as E
-import qualified Data.Vector as V
+import           Control.Concurrent          (ThreadId, forkIOWithUnmask, killThread, myThreadId,
+                                              threadDelay)
+import           Control.Concurrent.STM
+import           Control.Exception           (SomeException, mask, mask_, onException)
+import qualified Control.Exception           as E
+import           Control.Monad               (forM_, forever, join, liftM3, unless, when)
+import           Data.Foldable               (foldMap')
+import           Data.Hashable               (hash)
+import           Data.IORef                  (IORef, mkWeakIORef, newIORef)
+import           Data.List                   (partition)
+import           Data.Monoid                 (Sum (..))
+import           Data.Time.Clock             (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime)
+import           Data.Typeable               (Typeable)
+import qualified Data.Vector                 as V
+import           GHC.Conc.Sync               (labelThread)
 
-#if MIN_VERSION_monad_control(0,3,0)
-import Control.Monad.Trans.Control (MonadBaseControl, control)
-import Control.Monad.Base (liftBase)
-#else
-import Control.Monad.IO.Control (MonadControlIO, controlIO)
-import Control.Monad.IO.Class (liftIO)
-#define control controlIO
-#define liftBase liftIO
-#endif
-
-#if MIN_VERSION_base(4,3,0)
-import Control.Exception (mask)
-#else
--- Don't do any async exception protection for older GHCs.
-mask :: ((forall a. IO a -> IO a) -> IO b) -> IO b
-mask f = f id
-#endif
+import           Control.Monad.Base          (liftBase)
+import           Control.Monad.Trans.Control (MonadBaseControl, control)
 
 -- | A single resource pool entry.
 data Entry a = Entry {
-      entry :: a
+      entry   :: a
     , lastUse :: UTCTime
     -- ^ Time of last return.
     }
 
 -- | A single striped pool.
 data LocalPool a = LocalPool {
-      inUse :: TVar Int
+      inUse   :: TVar Int
     -- ^ Count of open entries (both idle and in use).
     , entries :: TVar [Entry a]
     -- ^ Idle entries.
-    , lfin :: IORef ()
+    , lfin    :: IORef ()
     -- ^ empty value used to attach a finalizer to (internal)
     } deriving (Typeable)
 
 data Pool a = Pool {
-      create :: IO a
+      create       :: IO a
     -- ^ Action for creating a new entry to add to the pool.
-    , destroy :: a -> IO ()
+    , destroy      :: a -> IO ()
     -- ^ Action for destroying an entry that is now done with.
-    , numStripes :: Int
+    , numStripes   :: Int
     -- ^ The number of stripes (distinct sub-pools) to maintain.
     -- The smallest acceptable value is 1.
-    , idleTime :: NominalDiffTime
+    , idleTime     :: NominalDiffTime
     -- ^ Amount of time for which an unused resource is kept alive.
     -- The smallest acceptable value is 0.5 seconds.
     --
@@ -113,9 +98,9 @@ data Pool a = Pool {
     -- Requests for resources will block if this limit is reached on a
     -- single stripe, even if other stripes have idle resources
     -- available.
-    , localPools :: V.Vector (LocalPool a)
+    , localPools   :: V.Vector (LocalPool a)
     -- ^ Per-capability resource pools.
-    , fin :: IORef ()
+    , fin          :: IORef ()
     -- ^ empty value used to attach a finalizer to (internal)
     } deriving (Typeable)
 
@@ -250,11 +235,7 @@ purgeLocalPool destroy LocalPool{..} = do
 -- a subsequent user (who expects the resource to be valid) to throw
 -- an exception.
 withResource ::
-#if MIN_VERSION_monad_control(0,3,0)
     (MonadBaseControl IO m)
-#else
-    (MonadControlIO m)
-#endif
   => Pool a -> (a -> m b) -> m b
 {-# SPECIALIZE withResource :: Pool a -> (a -> IO b) -> IO b #-}
 withResource pool act = control $ \runInIO -> mask $ \restore -> do
@@ -263,9 +244,7 @@ withResource pool act = control $ \runInIO -> mask $ \restore -> do
             destroyResource pool local resource
   putResource local resource
   return ret
-#if __GLASGOW_HASKELL__ >= 700
 {-# INLINABLE withResource #-}
-#endif
 
 -- | Take a resource from the pool, following the same results as
 -- 'withResource'. Note that this function should be used with caution, as
@@ -288,9 +267,7 @@ takeResource pool@Pool{..} = do
         return $
           create `onException` atomically (modifyTVar_ inUse (subtract 1))
   return (resource, local)
-#if __GLASGOW_HASKELL__ >= 700
 {-# INLINABLE takeResource #-}
-#endif
 
 -- | Similar to 'withResource', but only performs the action if a resource could
 -- be taken from the pool /without blocking/. Otherwise, 'tryWithResource'
@@ -298,11 +275,7 @@ takeResource pool@Pool{..} = do
 -- Conversely, if a resource can be borrowed from the pool without blocking, the
 -- action is performed and it's result is returned, wrapped in a 'Just'.
 tryWithResource :: forall m a b.
-#if MIN_VERSION_monad_control(0,3,0)
     (MonadBaseControl IO m)
-#else
-    (MonadControlIO m)
-#endif
   => Pool a -> (a -> m b) -> m (Maybe b)
 tryWithResource pool act = control $ \runInIO -> mask $ \restore -> do
   res <- tryTakeResource pool
@@ -313,9 +286,7 @@ tryWithResource pool act = control $ \runInIO -> mask $ \restore -> do
       putResource local resource
       return ret
     Nothing -> restore . runInIO $ return (Nothing :: Maybe b)
-#if __GLASGOW_HASKELL__ >= 700
 {-# INLINABLE tryWithResource #-}
-#endif
 
 -- | A non-blocking version of 'takeResource'. The 'tryTakeResource' function
 -- returns immediately, with 'Nothing' if the pool is exhausted, or @'Just' (a,
@@ -336,20 +307,16 @@ tryTakeResource pool@Pool{..} = do
             return $ Just <$>
               create `onException` atomically (modifyTVar_ inUse (subtract 1))
   return $ (flip (,) local) <$> resource
-#if __GLASGOW_HASKELL__ >= 700
 {-# INLINABLE tryTakeResource #-}
-#endif
 
 -- | Get a (Thread-)'LocalPool'
 --
 -- Internal, just to not repeat code for 'takeResource' and 'tryTakeResource'
 getLocalPool :: Pool a -> IO (LocalPool a)
 getLocalPool Pool{..} = do
-  i <- liftBase $ ((`mod` numStripes) . hash) <$> myThreadId
+  i <- liftBase $ (`mod` numStripes) . hash <$> myThreadId
   return $ localPools V.! i
-#if __GLASGOW_HASKELL__ >= 700
 {-# INLINABLE getLocalPool #-}
-#endif
 
 -- | Destroy a resource. Note that this will ignore any exceptions in the
 -- destroy function.
@@ -357,18 +324,14 @@ destroyResource :: Pool a -> LocalPool a -> a -> IO ()
 destroyResource Pool{..} LocalPool{..} resource = do
    destroy resource `E.catch` \(_::SomeException) -> return ()
    atomically (modifyTVar_ inUse (subtract 1))
-#if __GLASGOW_HASKELL__ >= 700
 {-# INLINABLE destroyResource #-}
-#endif
 
 -- | Return a resource to the given 'LocalPool'.
 putResource :: LocalPool a -> a -> IO ()
 putResource LocalPool{..} resource = do
     now <- getCurrentTime
     atomically $ modifyTVar_ entries (Entry resource now:)
-#if __GLASGOW_HASKELL__ >= 700
 {-# INLINABLE putResource #-}
-#endif
 
 -- | Destroy all resources in all stripes in the pool. Note that this
 -- will ignore any exceptions in the destroy function.

--- a/resource-pool.cabal
+++ b/resource-pool.cabal
@@ -46,6 +46,16 @@ library
 
   ghc-options: -Wall
 
+test-suite resource-pool-tests
+  ghc-options: -threaded -rtsopts
+  type: exitcode-stdio-1.0
+  build-depends:
+      base
+    , hspec
+    , resource-pool
+  hs-source-dirs: test
+  main-is: Main.hs
+
 source-repository head
   type:     git
   location: http://github.com/bos/pool

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE BlockArguments     #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+module Main (main) where
+
+import           Test.Hspec
+
+import           Control.Concurrent     (forkIO, threadDelay)
+import           Control.Exception      (Exception (fromException))
+import           Control.Exception.Base (IOException, SomeException)
+import           Data.Maybe             (isJust)
+import           Data.Pool
+import           Debug.Trace            (traceShow)
+
+main :: IO ()
+main = hspec $ do
+  describe "acquiring resources" $ do
+    it "acquire a single available resource" $
+      canAcquireSingleItem `shouldReturn` ()
+    it "throw when timeout expires and no resource is available" $
+      acquiringThrowsWhenTimeoutExpired `shouldThrow` timeoutException
+    it "acquires resource after it was released" $
+      acquireReleaseAndReAcquire `shouldReturn` ()
+    it "acquire resource with a delay shorter than the timeout" $
+      acquireWaitAndRelease `shouldReturn` ()
+    it "throw when waiting for longer than timeout" $
+      acquireAndWaitTooLong `shouldThrow` timeoutException
+
+timeoutException :: Selector TimeoutException
+timeoutException = const True
+  
+mkPool :: IO (Pool ())
+mkPool =
+  createPool'
+    (pure ())
+    (const (pure ()))
+    stripes
+    idleTime
+    maxResources
+    timeout
+  where
+    stripes = 1
+    idleTime = 1000
+    maxResources = 1
+    timeout = Just 1
+
+canAcquireSingleItem :: IO ()
+canAcquireSingleItem =
+  mkPool >>= fmap fst . takeResource
+
+acquiringThrowsWhenTimeoutExpired :: IO ()
+acquiringThrowsWhenTimeoutExpired = do
+  pool <- mkPool
+  _ <- takeResource pool
+  fst <$> takeResource pool
+
+acquireReleaseAndReAcquire :: IO ()
+acquireReleaseAndReAcquire = do
+  pool <- mkPool
+  (res, lp) <- takeResource pool
+  putResource lp res
+  fst <$> takeResource pool
+
+acquireWaitAndRelease :: IO ()
+acquireWaitAndRelease = do
+  pool <- mkPool
+  (res, lp) <- takeResource pool
+  _ <- forkIO do
+    threadDelay 300_000
+    putResource lp res
+  fst <$> takeResource pool
+
+acquireAndWaitTooLong :: IO ()
+acquireAndWaitTooLong = do
+  pool <- mkPool
+  (res, lp) <- takeResource pool
+  _ <- forkIO do
+    threadDelay 2_000_000
+    putResource lp res
+  fst <$> takeResource pool


### PR DESCRIPTION
This is part of hasura/graphql-engine#6326

Please notice that there are three commits:
- the first drops support for old GHC's (in order to simplify the code), and runs stylish haskell
- add a new field (`Maybe NominalDiffTime`), add a new smart constructor (`createPool'`), and get `takeResource` to throw if the timeout is reached (`withResource` also throws because it uses `takeResource`)
- add tests for the most common use cases I could think of

This is the second attempt at adding this functionality (see #1). The first one was to return `Maybe a` instead of throwing an exception. The problem there is that it's a breaking change and we use other libraries (e.g., `hedis`) which use this library, so the cost of that breaking change becomes a tad too high.